### PR TITLE
fix(#10): 1685 Jamaica

### DIFF
--- a/e164.js
+++ b/e164.js
@@ -240,6 +240,7 @@ var lookup, prefixes = {
   "1681": [ "US", "United States" ],
   "1682": [ "US", "United States" ],
   "1684": [ "AS", "American Samoa" ],
+  "1685": [ "JM", "Jamaica" ],
   "1700": [ "US", "United States" ],
   "1701": [ "US", "United States" ],
   "1702": [ "US", "United States" ],


### PR DESCRIPTION
assigns 1685 dialing prefix to Jamaica as of #10  